### PR TITLE
Add LoRA metadata handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ Si tienes sugerencias o quieres colaborar, ¡eres bienvenido!
 - `smart_lora_manager/lora_manager.py` contiene la implementación básica de los nodos.
 
 Estos nodos son un punto de partida para gestionar múltiples LoRAs de forma sencilla. El de **Load LoRAs** busca archivos `.safetensors` o `.ckpt` en un directorio y los devuelve como una lista de rutas. **Smart LoRA Selector** activa automáticamente aquellos LoRAs mencionados en el prompt.
+
+## Uso de categorías
+
+Cada LoRA puede incluir un campo `category` en sus metadatos. `Load LoRAs` lee esa información (desde el propio archivo `.safetensors` o un JSON con el mismo nombre) y devuelve un mapeo en formato JSON donde la clave es la ruta del archivo y el valor su categoría. Esto permite agrupar modelos por personaje, estilo u otra clasificación que desees.
+
+Si un archivo no tiene categoría definida, simplemente se deja vacío. Los nodos futuros podrán aprovechar este dato para filtrar o mostrar los LoRAs de forma ordenada.

--- a/smart_lora_manager/lora_manager.py
+++ b/smart_lora_manager/lora_manager.py
@@ -1,4 +1,20 @@
 import os
+from dataclasses import dataclass
+import json
+from typing import Dict, Optional
+
+try:
+    from safetensors.torch import safe_open
+except Exception:  # pragma: no cover - safetensors optional
+    safe_open = None
+
+@dataclass
+
+class LoRAMetadata:
+    path: str
+    name: str
+    category: str | None = None
+
 
 class LoadLoRAs:
     """Carga archivos LoRA desde un directorio."""
@@ -12,13 +28,38 @@ class LoadLoRAs:
     FUNCTION = "load"
     CATEGORY = "SmartLoRA"
 
+    def _read_metadata(self, path: str) -> LoRAMetadata:
+        base, ext = os.path.splitext(path)
+        category: Optional[str] = None
+
+        if ext == ".safetensors" and safe_open is not None:
+            try:
+                with safe_open(path, framework="pt") as f:
+                    meta = f.metadata() or {}
+                    category = meta.get("category")
+            except Exception:
+                pass
+
+        sidecar = f"{base}.json"
+        if category is None and os.path.isfile(sidecar):
+            try:
+                with open(sidecar, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+                    category = data.get("category")
+            except Exception:
+                pass
+
+        return LoRAMetadata(path=path, name=os.path.basename(base), category=category)
+
     def load(self, directory):
-        files = []
+        metadata: Dict[str, Optional[str]] = {}
         if os.path.isdir(directory):
             for name in os.listdir(directory):
                 if name.endswith((".safetensors", ".ckpt")):
-                    files.append(os.path.join(directory, name))
-        return ("\n".join(files),)
+                    path = os.path.join(directory, name)
+                    meta = self._read_metadata(path)
+                    metadata[path] = meta.category
+        return (json.dumps(metadata),)
 
 
 class SmartLoRASelector:
@@ -40,8 +81,14 @@ class SmartLoRASelector:
 
     def select(self, loras, prompt):
         weights = []
-        for path in loras.splitlines():
+        try:
+            mapping: Dict[str, Optional[str]] = json.loads(loras)
+        except json.JSONDecodeError:
+            mapping = {p: None for p in loras.splitlines() if p}
+
+        for path in mapping.keys():
             name = os.path.splitext(os.path.basename(path))[0].lower()
             if name in prompt.lower():
                 weights.append(f"{path}:1.0")
+
         return ("\n".join(weights),)


### PR DESCRIPTION
## Summary
- support LoRA categories via new `LoRAMetadata` dataclass
- parse metadata in `LoadLoRAs` using `safetensors` or sidecar JSON
- output a JSON map of file paths to categories
- update `SmartLoRASelector` to accept the new JSON format
- document category usage in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842276e02e8832b98f7154359e9bdae