### PR TITLE
Add regex-based LoRA selection with synonyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Si tienes sugerencias o quieres colaborar, ¡eres bienvenido!
 - `smart_lora_manager/__init__.py` registra los nodos para ComfyUI.
 - `smart_lora_manager/lora_manager.py` contiene la implementación básica de los nodos.
 
-Estos nodos son un punto de partida para gestionar múltiples LoRAs de forma sencilla. El de **Load LoRAs** busca archivos `.safetensors` o `.ckpt` en un directorio y los devuelve como una lista de rutas. **Smart LoRA Selector** activa automáticamente aquellos LoRAs mencionados en el prompt.
+Estos nodos son un punto de partida para gestionar múltiples LoRAs de forma sencilla. El de **Load LoRAs** busca archivos `.safetensors` o `.ckpt` en un directorio y los devuelve como una lista de rutas. **Smart LoRA Selector** detecta palabras clave o sinónimos en el prompt para activar automáticamente los modelos correspondientes. El diccionario de sinónimos se define en `smart_lora_manager/synonyms.yaml` y puede modificarse a gusto.
 
 ## Uso de categorías
 

--- a/smart_lora_manager/synonyms.yaml
+++ b/smart_lora_manager/synonyms.yaml
@@ -1,0 +1,6 @@
+catgirl:
+  - nekomimi
+  - "cat girl"
+warrior:
+  - fighter
+  - soldier


### PR DESCRIPTION
## Summary
- match LoRA names with word-boundary regex and synonym lists
- add configurable `synonyms.yaml`
- document the new behaviour in README

## Testing
- `python -m py_compile smart_lora_manager/*.py`
- `pip install pyyaml`

------
https://chatgpt.com/codex/tasks/task_e_684228a1e510832b81cf05e102bdefd9