### PR TITLE
Add LoRA preset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ Si un archivo no tiene categoría definida, simplemente se deja vacío. Los nodo
 ## Ajuste de pesos
 
 El nodo **LoRA Weight Slider** toma la salida de **Smart LoRA Selector** y permite modificar el peso aplicado a todos los modelos seleccionados usando un deslizador. Basta conectar la lista de pesos detectados a este nodo y escoger el valor deseado para que se reemplacen los pesos por el indicado.
+
+## Guardar y cargar presets
+
+Con **Save LoRA Preset** puedes almacenar la lista de LoRAs activos y sus pesos en un archivo JSON:
+
+```text
+weights = "path/to/lora1.safetensors:1.0\npath/to/lora2.safetensors:0.8"
+```
+
+Conectando esa cadena al nodo y eligiendo una ruta se genera `preset.json`. Luego **Load LoRA Preset** lee dicho archivo y devuelve el formato de pesos para reutilizarlo en cualquier flujo.
+
+

--- a/smart_lora_manager/__init__.py
+++ b/smart_lora_manager/__init__.py
@@ -1,13 +1,17 @@
-from .lora_manager import LoadLoRAs, SmartLoRASelector, LoRAWeightSlider
+from .lora_manager import LoadLoRAs, SmartLoRASelector, LoRAWeightSlider, SaveLoRAPreset, LoadLoRAPreset
 
 NODE_CLASS_MAPPINGS = {
     "LoadLoRAs": LoadLoRAs,
     "SmartLoRASelector": SmartLoRASelector,
     "LoRAWeightSlider": LoRAWeightSlider,
+    "SaveLoRAPreset": SaveLoRAPreset,
+    "LoadLoRAPreset": LoadLoRAPreset,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "LoadLoRAs": "Load LoRAs",
     "SmartLoRASelector": "Smart LoRA Selector",
     "LoRAWeightSlider": "LoRA Weight Slider",
+    "SaveLoRAPreset": "Save LoRA Preset",
+    "LoadLoRAPreset": "Load LoRA Preset",
 }

--- a/smart_lora_manager/lora_manager.py
+++ b/smart_lora_manager/lora_manager.py
@@ -5,6 +5,7 @@ import re
 from typing import Dict, Optional, List
 
 import yaml
+from .preset_manager import PresetManager
 
 try:
     from safetensors.torch import safe_open
@@ -154,3 +155,55 @@ class LoRAWeightSlider:
                 path = line
             result.append(f"{path}:{weight}")
         return ("\n".join(result),)
+
+
+
+class SaveLoRAPreset:
+    """Guarda la lista de LoRAs y pesos en un archivo JSON."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "weights": ("STRING", {}),
+                "path": ("STRING", {"default": "preset.json"}),
+                "preview": ("BOOLEAN", {"default": False}),
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("path",)
+    FUNCTION = "save"
+    CATEGORY = "SmartLoRA"
+
+    def save(self, weights: str, path: str, preview: bool = False):
+        manager = PresetManager(path)
+        manager.save(weights)
+        if preview:
+            manager.preview(weights)
+        return (path,)
+
+
+class LoadLoRAPreset:
+    """Carga un preset de LoRAs y devuelve el listado de pesos."""
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "path": ("STRING", {"default": "preset.json"}),
+                "preview": ("BOOLEAN", {"default": False}),
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("weights",)
+    FUNCTION = "load"
+    CATEGORY = "SmartLoRA"
+
+    def load(self, path: str, preview: bool = False):
+        manager = PresetManager(path)
+        weights = manager.load()
+        if preview:
+            manager.preview(weights)
+        return (weights,)

--- a/smart_lora_manager/preset_manager.py
+++ b/smart_lora_manager/preset_manager.py
@@ -1,0 +1,68 @@
+import json
+import os
+from typing import List, Dict, Any
+
+try:
+    import requests
+except Exception:  # pragma: no cover - requests optional
+    requests = None
+
+
+class PresetManager:
+    """Utility class to persist and preview LoRA weight presets."""
+
+    def __init__(self, path: str):
+        self.path = path
+
+    def _serialize(self, weights: str) -> List[Dict[str, Any]]:
+        data: List[Dict[str, Any]] = []
+        for line in weights.splitlines():
+            if not line:
+                continue
+            if ":" in line:
+                path, weight = line.split(":", 1)
+            else:
+                path, weight = line, "1.0"
+            try:
+                weight_f = float(weight)
+            except ValueError:
+                weight_f = 1.0
+            data.append({"path": path, "weight": weight_f})
+        return data
+
+    def _deserialize(self, data: Any) -> str:
+        lines = []
+        if isinstance(data, list):
+            for item in data:
+                try:
+                    lines.append(f"{item['path']}:{item['weight']}")
+                except Exception:
+                    pass
+        elif isinstance(data, dict):
+            for path, weight in data.items():
+                lines.append(f"{path}:{weight}")
+        return "\n".join(lines)
+
+    def save(self, weights: str) -> None:
+        os.makedirs(os.path.dirname(self.path) or ".", exist_ok=True)
+        with open(self.path, "w", encoding="utf-8") as fh:
+            json.dump(self._serialize(weights), fh, indent=2)
+
+    def load(self) -> str:
+        if not os.path.isfile(self.path):
+            return ""
+        try:
+            with open(self.path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            return ""
+        return self._deserialize(data)
+
+    def preview(self, weights: str) -> None:
+        """Invoke ComfyUI's preview API if available."""
+        if requests is None:
+            return
+        try:
+            requests.post("http://127.0.0.1:8188/preview", json={"weights": weights})
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- keep track of LoRA selections with a new `PresetManager`
- provide nodes to save or load preset files
- register new nodes and document their usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68422f62197c832bac9f729d07a423b9