### PR TITLE
Add unit tests for LoRA manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ weights = "path/to/lora1.safetensors:1.0\npath/to/lora2.safetensors:0.8"
 Conectando esa cadena al nodo y eligiendo una ruta se genera `preset.json`. Luego **Load LoRA Preset** lee dicho archivo y devuelve el formato de pesos para reutilizarlo en cualquier flujo.
 
 
+## Ejecutar pruebas
+
+Para correr la suite de tests unitarios asegúrate de tener instalado `pytest` y luego ejecuta:
+
+```bash
+pytest
+```
+

--- a/tests/test_lora_manager.py
+++ b/tests/test_lora_manager.py
@@ -1,0 +1,51 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import json
+import os
+
+from smart_lora_manager.lora_manager import LoadLoRAs, SmartLoRASelector, LoRAMetadata
+
+
+def test_load_loras_load(tmp_path, monkeypatch):
+    file1 = tmp_path / "model1.safetensors"
+    file1.write_text("")
+    file2 = tmp_path / "model2.ckpt"
+    file2.write_text("")
+    other = tmp_path / "notes.txt"
+    other.write_text("irrelevant")
+
+    categories = {
+        "model1.safetensors": "char",
+        "model2.ckpt": None,
+    }
+
+    def fake_read_metadata(self, path):
+        name = os.path.basename(path)
+        return LoRAMetadata(path=path, name=os.path.splitext(name)[0], category=categories[name])
+
+    monkeypatch.setattr(LoadLoRAs, "_read_metadata", fake_read_metadata)
+
+    loader = LoadLoRAs()
+    result_json, = loader.load(str(tmp_path))
+    mapping = json.loads(result_json)
+
+    assert mapping == {str(file1): "char", str(file2): None}
+
+
+def test_smart_lora_selector_select(monkeypatch):
+    selector = SmartLoRASelector()
+
+    synonyms = {"catgirl": ["nekomimi"], "warrior": ["fighter"]}
+    monkeypatch.setattr(SmartLoRASelector, "_load_synonyms", lambda self: synonyms)
+
+    mapping = {
+        "/tmp/catgirl.safetensors": None,
+        "/tmp/warrior.safetensors": None,
+    }
+    loras = json.dumps(mapping)
+
+    result, = selector.select(loras, "A brave nekomimi appears")
+    assert result == "/tmp/catgirl.safetensors:1.0"
+
+    result_empty, = selector.select(loras, "fighterplane approaching")
+    assert result_empty == ""


### PR DESCRIPTION
## Summary
- add `tests/test_lora_manager.py` with coverage for `LoadLoRAs.load` and `SmartLoRASelector.select`
- document how to run the tests using pytest in the README

## Testing
- `pip install pyyaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423044c140832b8e62099f1d1a5db5